### PR TITLE
Add workaround for `Tick()` and `time()`

### DIFF
--- a/core-games-api.def.lua
+++ b/core-games-api.def.lua
@@ -3063,3 +3063,9 @@ Visibility = {
 }
 --- @type CoreObject
 script = nil
+
+--- @return number
+function time() end
+
+--- @param deltaTime number
+function Tick(deltaTime) end

--- a/src/app.ts
+++ b/src/app.ts
@@ -164,6 +164,13 @@ async function run() {
   lines.push(...generateEnumsLines(coreLuaAPI.Enums));
   lines.push(getAnnotation('type', 'CoreObject'));
   lines.push('script = nil');
+  lines.push('');
+  lines.push('--- @return number');
+  lines.push('function time() end');
+  lines.push('');
+  lines.push('--- @param deltaTime number');
+  lines.push('function Tick(deltaTime) end');
+  lines.push('');
 
   fs.writeFileSync('core-games-api.def.lua', arrayToString(lines));
 }


### PR DESCRIPTION
This should prevent them from showing as undefined global.